### PR TITLE
Fix indicate same id bug when mutiple faces in frame

### DIFF
--- a/recognize.py
+++ b/recognize.py
@@ -211,6 +211,8 @@ def main():
                 face_image = frame[y1:y2, x1:x2]
                 thread = Thread(target=recognition, args=(face_image,))
                 thread.start()
+                
+                thread.join()
         
             if name == null:
                 continue


### PR DESCRIPTION
**Recognize thread bug when multiple faces are in frame**

Hello
It's recognized in a video with multiple faces in one frame, but individual face IDs come out the same, so I felt something was wrong. When I looked at the code, the `thread.join` part was missing, so I don't think the semaphore of global variables is guaranteed. So it can be solved by adding `thread.join`, but is it possible to modify it to a more general code?

